### PR TITLE
image-urlでbackground-imageを指定（heroku対応）

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -3,7 +3,7 @@
 
 body {
         background-color: #33CCFF;        
-        background-image: url("money_chokinbako.png");
+        background-image: image-url("money_chokinbako.png");
         background-position:80%;
         color: black; 
         font-family: Meiryo, sans-serif;


### PR DESCRIPTION
Herokuだと画像が表示されなかったので。
他の方法もありそうですが（Issue43）ひとまず応急処置
