### PR TITLE
twitterへのリンクがtwitterクラスを使うので、ボタンのクラス名を変更

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -16,7 +16,7 @@ body {
        color:black;
 }
 
-.twitter {
+.large-button {
         border: 1px solid #15aeec;
         background-color: #49c0f0;
         background-image: -webkit-linear-gradient(top, #49c0f0, #2cafe3);
@@ -28,26 +28,26 @@ body {
         transition: none;
         text-shadow: 0 1px 1px rgba(0, 0, 0, .3);
 }
-.twitter:hover {
+.large-button:hover {
         border:1px solid #1090c3;
         background-color: #1ab0ec;
         background-image: -webkit-linear-gradient(top, #1ab0ec, #1a92c2);
         background-image: linear-gradient(to bottom, #1ab0ec, #1a92c2);
 }
-.twitter:hover {
+.large-button:hover {
         border:1px solid #1090c3;
         background-color: #1ab0ec;
         background-image: -webkit-linear-gradient(top, #1ab0ec, #1a92c2);
         background-image: linear-gradient(to bottom, #1ab0ec, #1a92c2);
 }
 
-.twitter:active {
+.large-button:active {
         background: #1a92c2;
         box-shadow: inset 0 3px 5px rgba(0, 0, 0, .5);
         color: #1679a1;
         text-shadow: 0 1px 1px rgba(255, 255, 255, .5);
 }
-.twitter {
+.large-button {
         display: inline-block;
         width: 200px;
         height: 54px;
@@ -56,20 +56,19 @@ body {
         line-height: 54px;
         outline: none;
    }
-.twitter::before,
-.twitter::after {
+.large-button::before,
+.large-button::after {
         position: absolute;
         z-index: -1;
         display: block;
         content: '';
 }
-.twitter,
-.twitter::before,
-.twitter::after {
+.large-button,
+.large-button::before,
+.large-button::after {
         -webkit-box-sizing: border-box;
         -moz-box-sizing: border-box;
         box-sizing: border-box;
         -webkit-transition: all .3s;
         transition: all .3s;
 }	
-

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -22,14 +22,9 @@
        <option>8</option>
        <option>9</option>
        <input type="text" name="kane2" readonly="readonly" value="00円">
-       <input type="submit" class="twitter" tabIndex="0" id="twitter_button" value = 飲んだつもりにする！！>
+       <input type="submit" class="large-button" tabIndex="0" id="twitter_button" value = 飲んだつもりにする！！>
      <% end %>
     </div>
    </div>
  </body>
 </html>
-      
-   
-   
-    
-  

--- a/app/views/top/result.html.erb
+++ b/app/views/top/result.html.erb
@@ -1,9 +1,6 @@
 <html lang="ja">
   <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <link href="css/bootstrap.min.css" rel="stylesheet">
-        <script type="text/javascript" src="javascript/test.js"></script>
-        <link rel="stylesheet" type="text/css" href="style.css">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
   </head>
   <body>
@@ -23,12 +20,12 @@
        <% end %>
   <% if user_signed_in? %>
    <% if @total_before == @total_after %>
-   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。これが初めての貯金です！%23したつもり貯金 %23どや %23aiit_enpit" class="twitter-share-button" data-lang="ja">Twitterでシェア</a></div>
+   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。これが初めての貯金です！%23したつもり貯金 %23どや %23aiit_enpit" class="twitter-share-button" data-lang="ja" data-size="large">Twitterでシェア</a></div>
    <% else %>
-   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。今までに<%=@total_after%>円貯金しました！%23したつもり貯金 %23どや %23aiit_enpit"class="twitter-share-button" data-lang="ja">Twitterでシェア</a></div>
+   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。今までに<%=@total_after%>円貯金しました！%23したつもり貯金 %23どや %23aiit_enpit"class="twitter-share-button" data-lang="ja" data-size="large">Twitterでシェア</a></div>
    <% end %>
  <% else %>
-   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。%23したつもり貯金 %23どや %23aiit_enpit" class="twitter-share-button" data-lang="ja">Twitterでシェア</a></div>
+   <div class="twitter"><a href="http://twitter.com/share?url=https://goo.gl/D6RWc0&amp;text=<%=@total_before%>円節約しました。%23したつもり貯金 %23どや %23aiit_enpit" class="twitter-share-button" data-lang="ja" data-size="large">Twitterでシェア</a></div>
    <!--   </form> -->
  <% end %>
  <a class="twitter-timeline"  href="https://twitter.com/hashtag/%E3%81%97%E3%81%9F%E3%81%A4%E3%82%82%E3%82%8A%E8%B2%AF%E9%87%91" data-widget-id="785352546680352768">#したつもり貯金 のツイート</a>
@@ -49,7 +46,6 @@
     });
   });
 </script>
-    <script src="js/bootstorap.min.js"></script>
   </div>
   </body>
 </html>


### PR DESCRIPTION
森籐さんに作ってもらったトップページのボタンでtweetというclassを使っていましたが、
Twitterへのつぶやきリンクが

```
<div class="twitter">
```

を使うため、Tweetするためのリンクにも適用されていました。
それによりレイアウトが崩れていたので、影響を避けるために、トップページのボタンのclassをlarge-buttonに変更しました。

その他、ツイートボタンを大きめにしたのと、resultページに合った不要なcssとjsの読み込みを削除しました
